### PR TITLE
メッセージデータのお掃除機能追加

### DIFF
--- a/WinWwamk.cpp
+++ b/WinWwamk.cpp
@@ -2206,7 +2206,10 @@ LRESULT CALLBACK SelectObjectDialogProc( HWND hWnd, UINT message, WPARAM wParam,
 		//物体データの消去
 		else if( LOWORD(wParam) == IDC_BUTTON_MAP_ERASE ){
 			int i;
+			const int messageIndex = objectAttribute[g_SelectObjectData][ATR_STRING];
 			for( i = 0 ; i < OBJECT_ATR_MAX ; ++i ) objectAttribute[g_SelectObjectData][i] = 0;
+			g_StrMessage[messageIndex][0] = '\0';
+
 			InvalidateRect( hWnd, NULL, FALSE );
 			InvalidateRect( g_hWnd, NULL, FALSE );
 		}
@@ -2320,7 +2323,10 @@ LRESULT CALLBACK SelectMapDialogProc( HWND hWnd, UINT message, WPARAM wParam, LP
 		//背景データの消去
 		else if( LOWORD(wParam) == IDC_BUTTON_MAP_ERASE ){
 			int i;
+			const int messageIndex = mapAttribute[g_SelectMapData][ATR_STRING];
 			for( i = 0 ; i < MAP_ATR_MAX ; ++i ) mapAttribute[g_SelectMapData][i] = 0;
+			g_StrMessage[messageIndex][0] = '\0';
+			
 			InvalidateRect( hWnd, NULL, FALSE );
 			InvalidateRect( g_hWnd, NULL, FALSE );
 		}
@@ -3730,7 +3736,6 @@ void SetMessageData( int *point, char *str )
 		strcpy( g_StrMessage[*point], str );
 	}
 }
-
 
 
 //##------------------------------------------------------------------

--- a/WinWwamk.cpp
+++ b/WinWwamk.cpp
@@ -1774,6 +1774,8 @@ BOOL SaveMapData( char *FileName )
 	int checkData = 0;
 	char szSavePassword[30];
 	int xmax, ymax;
+	// 各メッセージデータが利用されているか確認する配列
+	BOOL usedMessage[MESSAGE_NUMBER_MAX];
 
 	//ダイアログ閉じる
 	DestroyWindow( g_hDlgObject );
@@ -1781,6 +1783,7 @@ BOOL SaveMapData( char *FileName )
 	DestroyWindow( g_hDlgSelectChara );
 
 	for( i = 0 ; i < 100 ; ++i ) PressData[i] = 0;
+	for (i = 0; i < MESSAGE_NUMBER_MAX; ++i) usedMessage[i] = FALSE;
 
 	PressData[DATA_VERSION] = 31;
 	PressData[DATA_STATUS_ENERGYMAX] = (char)statusEnergyMax;
@@ -1855,6 +1858,10 @@ BOOL SaveMapData( char *FileName )
 	PressData[DATA_MAP_COUNT +1] = (char)(number >> 8);
 
 	for( i = 0 ; i < number ; ++i ){
+		//メッセージデータに使用済みと記録
+		if (mapAttribute[i][ATR_STRING] != 0) {
+			usedMessage[mapAttribute[i][ATR_STRING]] = TRUE;
+		}
 		for( j = 0 ; j < MAP_ATR_MAX ; ++j ){
 			PressData[pointer] = (char)mapAttribute[i][j];
 			++pointer;
@@ -1872,6 +1879,9 @@ BOOL SaveMapData( char *FileName )
 	PressData[DATA_OBJECT_COUNT +1] = (char)(number >> 8);
 
 	for( i = 0 ; i < number ; ++i ){
+		if (objectAttribute[i][ATR_STRING] != 0) {
+			usedMessage[objectAttribute[i][ATR_STRING]] = TRUE;
+		}
 		for( j = 0 ; j < OBJECT_ATR_MAX ; ++j ){
 			PressData[pointer] = (char)objectAttribute[i][j];
 			++pointer;
@@ -1938,7 +1948,13 @@ BOOL SaveMapData( char *FileName )
 	//新暗証番号
 	saveMapString( szSavePassword );
 	//メッセージデータの書き込み
-	for( i = 0 ; i < g_iMesNumberMax ; ++i ) saveMapString( g_StrMessage[i] );
+	for (i = 0; i < g_iMesNumberMax; ++i) {
+		if (usedMessage[i] == TRUE) {
+			saveMapString(g_StrMessage[i]);
+		} else {
+			saveMapString("");
+		}
+	}
 	//その他データ
 	saveMapString( g_worldName );
 	saveMapString( "" );

--- a/WinWwamk.cpp
+++ b/WinWwamk.cpp
@@ -3730,6 +3730,7 @@ void SetMessageData( int *point, char *str )
 		//メッセージ格納
 		strcpy( g_StrMessage[*point], str );
 	} else if( strlen(str) == 0 ){
+		g_StrMessage[*point][0] = '\0';
 		*point = 0;
 	} else {
 		//メッセージ格納

--- a/WinWwamk.cpp
+++ b/WinWwamk.cpp
@@ -1693,6 +1693,7 @@ BOOL LoadMapData( char *FileName )
 	}
 
 	//メッセージデータの読みだし
+	ZeroMemory(g_StrMessage, MESSAGE_NUMBER_MAX * MESSAGE_STR_MAX);
 	pointer = point2;
 
 	//バージョンアップ中テスト互換用


### PR DESCRIPTION
#6 のプルリクエストです。

下記ToDoで試したあとは [WWAMessageLoader](https://github.com/aokashi/WWAMessageLoader) で該当のメッセージが消えているか確かめましょう。

## ToDo
- [x] 物体パーツを消去するとメッセージデータも消えるようになる。
- [x] 背景パーツを消去するとメッセージデータも消えるようになる。
- [x] メッセージを空欄にしてもメッセージデータが消えるようになる。
- ~~マップデータ保存時に不要なメッセージデータが消えるようになる。~~ → 読込時に移行
- [x] マップデータ読込時に読み込み前のメッセージデータが残らないようになる。